### PR TITLE
Fix: Add createData in in GetOneNewsDto ,update PetitionStatus to Only Change Status in PetitonsStatus.진행중

### DIFF
--- a/src/main/java/com/rtsoju/dku_council_homepage/domain/post/entity/dto/response/ResponseNewsDto.java
+++ b/src/main/java/com/rtsoju/dku_council_homepage/domain/post/entity/dto/response/ResponseNewsDto.java
@@ -5,6 +5,7 @@ import com.rtsoju.dku_council_homepage.domain.post.entity.subentity.News;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -18,6 +19,8 @@ public class ResponseNewsDto {
     private List<FileUrlWithNameDto> files = new ArrayList<>();
     private List<PageCommentDto> commentList = new ArrayList<>();
     private String writer;
+    private LocalDateTime createDate;
+
 
     public ResponseNewsDto(News news) {
         this.id = news.getId();
@@ -26,6 +29,7 @@ public class ResponseNewsDto {
         this.text = news.getText();
         this.commentList = news.getComments().stream().map(PageCommentDto::new).collect(Collectors.toList());
         this.files = news.getFiles();
+        this.createDate = news.getCreateDate();
     }
 
 

--- a/src/main/java/com/rtsoju/dku_council_homepage/domain/post/service/PetitionService.java
+++ b/src/main/java/com/rtsoju/dku_council_homepage/domain/post/service/PetitionService.java
@@ -97,7 +97,7 @@ public class PetitionService {
         Petition petition = petitionRepository.findById(postId).orElseThrow(FindPostWithIdNotFoundException::new);
         User user = userRepository.findById(userId).orElseThrow(FindUserWithIdNotFoundException::new);
         Comment comment = new Comment(petition, user, data.getText());
-        if(petition.getComments().size() >= accept){
+        if (petition.getStatus() == PetitionStatus.진행중 && petition.getComments().size() >= accept) {
             petition.UpdateStandBy();
         }
         return commentRepository.save(comment);


### PR DESCRIPTION
1. 총학소식 단건조회 생성일 데이터 추가
2. 청원진행 댓글수가 100개 이상일 때 진행중인 상태에서만 답변대기로 상태 변경되게 수정